### PR TITLE
Support Rotary Positional Embedding (RoPE) on Apple Silicon devices using jax-metal

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
     )
     # Load the model parameters
     params_path = args.params_path
+    print("Loading model parameters from: ", params_path)
     params = load_params(params_path)
     print("Generating text...")
     # Sample from the model


### PR DESCRIPTION
Replaced `einops` and `einsum` operations with basic `jax` operations as they are not supported by jax-metal yet.
Fixes #3 